### PR TITLE
Maj References pour Cog 2023

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# @etalab/gazetteer
+# @ban-team/gazetteer
 
 Bibliothèque permettant de déterminer le découpage administratif dans lequel se trouve des coordonnées géographiques au format WGS-84.
 
@@ -24,7 +24,7 @@ NB : Les géométries des collectivités d'outremer proviennent d'OSM.
 ⚠️ Le chemin d’accès aux données doit être renseigné, soit via le paramètre `dbPath`, soit via la variable d’environnement `GAZETTEER_DB_PATH`.
 
 ```js
-const {createGazetteer} = require('@etalab/gazetteer')
+const {createGazetteer} = require('@ban-team/gazetteer')
 
 const g = await createGazetteer(options)
 await g.find({lon: 5.9225, lat: 49.2741})

--- a/build/index.js
+++ b/build/index.js
@@ -11,8 +11,8 @@ const {readShapefile} = require('./read-shapefile')
 
 const gunzip = promisify(zlib.gunzip)
 
-const COMMUNES_URL = 'http://etalab-datasets.geo.data.gouv.fr/contours-administratifs/2022/geojson/communes-5m.geojson.gz'
-const COMMUNES_ANCIENNES_URL = 'https://osm13.openstreetmap.fr/~cquest/openfla/export/communes-anciennes-20220101-shp.zip'
+const COMMUNES_URL = 'http://etalab-datasets.geo.data.gouv.fr/contours-administratifs/2023/geojson/communes-5m.geojson.gz'
+const COMMUNES_ANCIENNES_URL = 'https://osm13.openstreetmap.fr/~cquest/openfla/export/communes-anciennes-20230101-shp.zip'
 
 function downloadFile(url) {
   return got(url).buffer()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ban-team/gazetteer",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Lightweight gazetteer for France 🇫🇷",
   "main": "index.js",
   "repository": "https://github.com/BaseAdresseNationale/gazetteer",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build": "node --max-old-space-size=8192 build"
   },
   "dependencies": {
-    "@etalab/decoupage-administratif": "^2.0.0",
+    "@etalab/decoupage-administratif": "^3.0.0",
     "@keyv/sqlite": "^3.0.0",
     "@turf/boolean-point-in-polygon": "^6.5.0",
     "flatbush": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@etalab/gazetteer",
+  "name": "@ban-team/gazetteer",
   "version": "1.0.0",
   "description": "Lightweight gazetteer for France 🇫🇷",
   "main": "index.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -38,10 +38,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@etalab/decoupage-administratif@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@etalab/decoupage-administratif/-/decoupage-administratif-2.0.0.tgz#24ee640070c47e3c62883873c35450197fa5f78c"
-  integrity sha512-X+pQDnm0Sk8T5KPhT5kU9cLyMKc+LagK8ObYxyzVDoQapjLNZl9/KY2VFr42aw4LEiTnUfqCgNZc9lhHfi6shQ==
+"@etalab/decoupage-administratif@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@etalab/decoupage-administratif/-/decoupage-administratif-3.0.0.tgz#1d0d54b5b884c3df9555b4b8db543f83559629d3"
+  integrity sha512-WlXHeArXK7zwcxoPev8NM3ncUjaIiBYiTmY1wh3X6RXITKjTwn3yaYdQqbPplTfFA/ByllG4Y4q4Jt0bCmbEzw==
 
 "@humanwhocodes/config-array@^0.9.2":
   version "0.9.3"


### PR DESCRIPTION
Pour la mise à jour du COG 2023 : 
- Mise à jour de la version decoupage administratif
- Mise à jour des urls "communes_anciennes_url" et "communes_url
Fix #13 
Ne pas merger cette modification avant que toutes les étapes pour le COG soient faites